### PR TITLE
fix(solc): metadata explicit disable

### DIFF
--- a/config.js
+++ b/config.js
@@ -264,6 +264,9 @@ function hardhat(userSettings) {
                 {
                     version: "0.6.12",
                     settings: {
+                          metadata: {
+                             bytecodeHash: "none",
+                          },
                         optimizer: {
                             enabled: true,
                             runs: 200,


### PR DESCRIPTION
explicitly disable bytecodeHash generation as this is machine-dependent